### PR TITLE
several daemon-related fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 -   always overwrite valkey.conf on installation
 -   use chrt instead of nice by default for xbatd for more reliable scheduling
+-   temporarily downgrade LIKWID to v5.3.0 due to errors on some architectures with v5.4.1
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
--   link to edit page on GitHub
+-   link to edit page and changelog on GitHub
+-   node info and benchmarks not being registered correctly
 
 ## v1.0.0 - 2025-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 -   always overwrite valkey.conf on installation
+-   use chrt instead of nice by default for xbatd for more reliable scheduling
 
 ### Fixed
 

--- a/src/backend/restapi/api/openapi.yml
+++ b/src/backend/restapi/api/openapi.yml
@@ -963,7 +963,7 @@ components:
         cpu:
           type: object
         gpu:
-          type: object
+          type: array
         memory:
           type: object
         os:

--- a/src/xbatd/xbatd.el8.dockerfile
+++ b/src/xbatd/xbatd.el8.dockerfile
@@ -29,8 +29,6 @@ ENV LIKWID_VERSION="v5.3.0"
 RUN git clone https://github.com/RRZE-HPC/likwid.git && cd likwid && git checkout "${LIKWID_VERSION}" && \
     sed -i -e 's!PREFIX ?= /usr/local#NO SPACE!PREFIX ?= /usr/local/share/xbatd/#NO SPACE!g' config.mk && \
     sed -i -e 's!MAX_NUM_THREADS = 500!MAX_NUM_THREADS = 1024!g' config.mk \
-    #&& sed -i -e 's!ACCESSMODE = accessdaemon#NO SPACE!ACCESSMODE = direct#NO SPACE!g' config.mk \
-    #&& sed -i -e 's!ACCESSDAEMON = $(SBINPREFIX)/likwid-accessD#NO SPACE!ACCESSDAEMON = /usr/local/share/xbatd/sbin/likwid-accessD#NO SPACE!g' config.mk \
     && make -j $(nproc) \
     && make install
 

--- a/src/xbatd/xbatd.el8.dockerfile
+++ b/src/xbatd/xbatd.el8.dockerfile
@@ -1,7 +1,5 @@
 FROM almalinux:8.10
 
-LABEL maintainer="NicoTippmann@MEGWARE"
-
 RUN dnf -y update && \
     dnf -y install epel-release && \
     dnf clean all

--- a/src/xbatd/xbatd.el8.dockerfile
+++ b/src/xbatd/xbatd.el8.dockerfile
@@ -27,7 +27,7 @@ ENV CQUESTDB_VERSION=4.0.4
 RUN git clone https://github.com/questdb/c-questdb-client.git && cd c-questdb-client && git checkout "$CQUESTDB_VERSION" && cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build
 
 # install LIKWID
-ENV LIKWID_VERSION="v5.4.1"
+ENV LIKWID_VERSION="v5.3.0"
 RUN git clone https://github.com/RRZE-HPC/likwid.git && cd likwid && git checkout "${LIKWID_VERSION}" && \
     sed -i -e 's!PREFIX ?= /usr/local#NO SPACE!PREFIX ?= /usr/local/share/xbatd/#NO SPACE!g' config.mk && \
     sed -i -e 's!MAX_NUM_THREADS = 500!MAX_NUM_THREADS = 1024!g' config.mk \

--- a/src/xbatd/xbatd.el9.dockerfile
+++ b/src/xbatd/xbatd.el9.dockerfile
@@ -1,7 +1,5 @@
 FROM almalinux:9.2
 
-LABEL maintainer="NicoTippmann@MEGWARE"
-
 RUN dnf -y update && \
     dnf -y install epel-release && \
     dnf clean all

--- a/src/xbatd/xbatd.el9.dockerfile
+++ b/src/xbatd/xbatd.el9.dockerfile
@@ -26,7 +26,7 @@ ENV CQUESTDB_VERSION=4.0.4
 RUN git clone https://github.com/questdb/c-questdb-client.git && cd c-questdb-client && git checkout "$CQUESTDB_VERSION" && cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build
 
 # install LIKWID
-ENV LIKWID_VERSION="v5.4.1"
+ENV LIKWID_VERSION="v5.3.0"
 RUN git clone https://github.com/RRZE-HPC/likwid.git && cd likwid && git checkout "${LIKWID_VERSION}" && \
     sed -i -e 's!PREFIX ?= /usr/local#NO SPACE!PREFIX ?= /usr/local/share/xbatd/#NO SPACE!g' config.mk && \
     sed -i -e 's!MAX_NUM_THREADS = 500!MAX_NUM_THREADS = 1024!g' config.mk \

--- a/src/xbatd/xbatd.el9.dockerfile
+++ b/src/xbatd/xbatd.el9.dockerfile
@@ -28,8 +28,6 @@ ENV LIKWID_VERSION="v5.3.0"
 RUN git clone https://github.com/RRZE-HPC/likwid.git && cd likwid && git checkout "${LIKWID_VERSION}" && \
     sed -i -e 's!PREFIX ?= /usr/local#NO SPACE!PREFIX ?= /usr/local/share/xbatd/#NO SPACE!g' config.mk && \
     sed -i -e 's!MAX_NUM_THREADS = 500!MAX_NUM_THREADS = 1024!g' config.mk \
-    #&& sed -i -e 's!ACCESSMODE = accessdaemon#NO SPACE!ACCESSMODE = direct#NO SPACE!g' config.mk \
-    #&& sed -i -e 's!ACCESSDAEMON = $(SBINPREFIX)/likwid-accessD#NO SPACE!ACCESSDAEMON = /usr/local/share/xbatd/sbin/likwid-accessD#NO SPACE!g' config.mk \
     && make -j $(nproc) \
     && make install
 

--- a/src/xbatd/xbatd.service
+++ b/src/xbatd/xbatd.service
@@ -20,10 +20,9 @@ TasksMax=1024
 # and may run into the limit on systems with high core count (segmentation violation) 
 LimitNOFILE=65536
 
-# Setting them in Environment= is not possible as the substitution via "$" does not work
 # LD_LIBRARY_PATH for liblikwid and PATH for likwid-accessD binary
-ExecStart=/bin/bash -c "PATH=$PATH:/usr/local/share/xbatd/sbin LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:/usr/lib64:/usr/local/share/xbatd/lib:/usr/local/share/xbatd/lib64 /usr/bin/nice -n -20 /usr/local/bin/xbatd"
+ExecStartPre=sysctl -w kernel.sched_rt_runtime_us=-1
+ExecStart=/bin/bash -c "PATH=$PATH:/usr/local/share/xbatd/sbin LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:/usr/lib64:/usr/local/share/xbatd/lib:/usr/local/share/xbatd/lib64 chrt -r 99 /usr/local/bin/xbatd"
 
-# WORKAROUND FOR SCHEDULING ISSUES
-#ExecStartPre=sysctl -w kernel.sched_rt_runtime_us=-1
-#ExecStart=/bin/bash -c "PATH=$PATH:/usr/local/share/xbatd/sbin LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:/usr/lib64:/usr/local/share/xbatd/lib:/usr/local/share/xbatd/lib64 chrt -r 99 /usr/local/bin/xbatd"
+# Alternative for chrt that does not work as reliably as the above
+#ExecStart=/bin/bash -c "PATH=$PATH:/usr/local/share/xbatd/sbin LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:/usr/lib64:/usr/local/share/xbatd/lib:/usr/local/share/xbatd/lib64 /usr/bin/nice -n -20 /usr/local/bin/xbatd"


### PR DESCRIPTION
- use chrt instead of nice by default for xbatd for more reliable scheduling
- fixed node info and benchmarks not being registered correctly
- temporarily downgrade LIKWID to v5.3.0 due to errors on some architectures with v5.4.1