### PR TITLE
fix build of xbatd and init submodules if not done yet during build

### DIFF
--- a/src/xbatd/build.sh
+++ b/src/xbatd/build.sh
@@ -49,6 +49,11 @@ VERSION=$1
 
 echo "Building Version $VERSION Release $RELEASE for $DISTRO"
 
+if git submodule status --recursive | grep -qE '^[-+]'; then
+    echo "Initializing git submodules..."
+    git submodule update --init --recursive || { echo "Failed to initialize git submodules"; exit 1; }
+fi
+
 $EXECUTOR build --build-arg "VERSION=$VERSION" --platform=linux/amd64 --build-arg "RELEASE=$RELEASE" -t "xbatd:${DISTRO}" -f "xbatd.${DISTRO}.dockerfile" .
 
 if [ $? -ne 0 ]; then

--- a/src/xbatd/xbatd.el8.dockerfile
+++ b/src/xbatd/xbatd.el8.dockerfile
@@ -28,7 +28,7 @@ RUN mkdir -p ~/rpmbuild/BUILD ~/rpmbuild/BUILDROOT ~/rpmbuild/RPMS ~/rpmbuild/SO
 RUN curl -fsSL -o /etc/yum.repos.d/cuda-rhel8.repo \
         https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && \
     microdnf -y install \
-        nvidia-driver nvidia-driver-NVML nvidia-driver-devel cuda-nvml-devel-12-2 && \
+        nvidia-driver nvidia-driver-devel cuda-nvml-devel-12-2 && \
     microdnf clean all
 
 # install rocm

--- a/src/xbatd/xbatd.el9.dockerfile
+++ b/src/xbatd/xbatd.el9.dockerfile
@@ -28,7 +28,7 @@ RUN mkdir -p ~/rpmbuild/BUILD ~/rpmbuild/BUILDROOT ~/rpmbuild/RPMS ~/rpmbuild/SO
 RUN curl -fsSL -o /etc/yum.repos.d/cuda-rhel9.repo \
         https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo && \
     microdnf -y install \
-        nvidia-driver nvidia-driver-NVML nvidia-driver-devel cuda-nvml-devel-12-2 && \
+        nvidia-driver nvidia-driver-devel cuda-nvml-devel-12-2 && \
     microdnf clean all
 
 # install rocm


### PR DESCRIPTION
`nvidia-driver-NVML` no longer provided by repo, `nvidia-driver-devel` should suffice