### PR TITLE
Disable automatic xbatd service enablement.

### DIFF
--- a/src/xbatd/xbatd.service
+++ b/src/xbatd/xbatd.service
@@ -1,6 +1,3 @@
-[Install]
-WantedBy=multi-user.target
-
 [Unit]
 Description=xbat measurement daemon
 Requires=network.target

--- a/src/xbatd/xbatd.spec
+++ b/src/xbatd/xbatd.spec
@@ -78,12 +78,10 @@ DESTDIR=%{buildroot} cmake --install build
 
 %post
 systemctl daemon-reload
-systemctl enable xbatd.service
 
 %preun
 if [ $1 -eq 0 ]; then
     systemctl stop xbatd.service
-    systemctl disable xbatd.service
 fi
 
 %postun


### PR DESCRIPTION
xbatd cannot run without an active Slurm job.
The service is started and stopped by Slurm prolog/epilog scripts instead of during system boot. Preventing automatic service enablement avoids the startup failure:

```
# systemctl status xbatd
● xbatd.service - xbat measurement daemon
   Loaded: loaded (/etc/systemd/system/xbatd.service; enabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Thu 2026-06-11 13:03:29 CEST; 1h 31min ago
 Main PID: 2392 (code=exited, status=1/FAILURE)

Jun 11 13:03:29 node0141 systemd[1]: Starting xbat measurement daemon...
Jun 11 13:03:29 node0141 sysctl[2325]: kernel.sched_rt_runtime_us = -1
Jun 11 13:03:29 node0141 systemd[1]: Started xbat measurement daemon.
Jun 11 13:03:29 node0141 bash[2392]: [2026-06-11, 13:03:29.560881][error]: Error reading file '/run/xbatd/job'
Jun 11 13:03:29 node0141 bash[2392]: Failed to read job ID from file
Jun 11 13:03:29 node0141 systemd[1]: xbatd.service: Main process exited, code=exited, status=1/FAILURE
Jun 11 13:03:29 node0141 systemd[1]: xbatd.service: Failed with result 'exit-code'.
```